### PR TITLE
Fix deadlock in fq_pop() and fq_peek()

### DIFF
--- a/function_queue.c
+++ b/function_queue.c
@@ -23,6 +23,11 @@
 #include "function_queue.h"
 #include "pt_error.h"
 
+static void release_mutex(void* m)
+{
+	(void) pthread_mutex_unlock((pthread_mutex_t*) m);
+}
+
 enum pt_error
 fq_init(struct function_queue* q, enum fqtype type, unsigned max_elements)
 {
@@ -167,10 +172,14 @@ fq_pop(struct function_queue* q, struct function_queue_element* e, int block)
 
 		if(is_empty) {
 			if(block) {
+				pthread_cleanup_push(release_mutex, &q->lock);
+
 				do {
 					pthread_cond_wait(&q->wait, &q->lock);
 					fq_is_empty(q, &is_empty);
 				} while(is_empty);
+
+				pthread_cleanup_pop(0);
 			} else {
 				ret = PT_EFQEMPTY;
 			}
@@ -225,10 +234,14 @@ fq_peek(struct function_queue* q, struct function_queue_element* e, int block)
 
 		if(is_empty) {
 			if(block) {
+				pthread_cleanup_push(release_mutex, &q->lock);
+
 				do {
 					pthread_cond_wait(&q->wait, &q->lock);
 					fq_is_empty(q, &is_empty);
 				} while(is_empty);
+
+				pthread_cleanup_pop(0);
 			} else {
 				ret = PT_EFQEMPTY;
 			}


### PR DESCRIPTION
This was caused by a deadlock in `fq_pop()`. The `lock` is reacquired during cancelation and was not released, deadlocking the other threads (this explains why thread 2 often exited without the others). A cleanup handler was added to fix this situation.

Fix #52 
