### PR TITLE
Change ret in fqpeek() and fqpop() to be volatile

### DIFF
--- a/function_queue.c
+++ b/function_queue.c
@@ -171,7 +171,7 @@ unlock_queue_mutex:
 enum qterror
 fqpop(struct function_queue* q, struct function_queue_element* e, int block)
 {
-	enum qterror ret = QTSUCCESS;
+	volatile enum qterror ret = QTSUCCESS;
 	int isempty = 0;
 
 	assert(q != NULL);
@@ -236,7 +236,7 @@ unlock_queue_mutex:
 enum qterror
 fqpeek(struct function_queue* q, struct function_queue_element* e, int block)
 {
-	enum qterror ret = QTSUCCESS;
+	volatile enum qterror ret = QTSUCCESS;
 	int isempty = 0;
 
 	assert(q != NULL);

--- a/makefile
+++ b/makefile
@@ -1,11 +1,11 @@
 
 OBJS=qtpool.o function_queue.o qterror.o indexed_array_queue.o linked_list_queue.o
 TESTEXECS=qterror_test
-CFLAGS=-fpic -DNDEBUG -D_XOPEN_SOURCE=500 -ansi -O2 -Wpedantic -Wall -Wextra -Werror -Wformat=2 -Wimplicit -Wparentheses -Wunused -Wuninitialized -Wstrict-aliasing -Wstrict-overflow=5 -Wfloat-equal -Wdeclaration-after-statement -Wundef -Wshadow -Wbad-function-cast -Wcast-qual -Wcast-align -Wwrite-strings -Wconversion -Wsizeof-pointer-memaccess -Waggregate-return -Wstrict-prototypes -Woverlength-strings -Wredundant-decls -Wnested-externs -Wc++-compat -Wno-error=c++-compat -Wmissing-prototypes -Wno-error=missing-prototypes -Wdisabled-optimization -Wno-error=disabled-optimization
+CFLAGS=-fpic -DNDEBUG -D_XOPEN_SOURCE=500 -ansi -O2 -Wpedantic -Wall -Wextra -Werror -Wformat=2 -Wimplicit -Wparentheses -Wunused -Wuninitialized -Wstrict-aliasing -Wstrict-overflow=5 -Wfloat-equal -Wdeclaration-after-statement -Wundef -Wshadow -Wbad-function-cast -Wcast-qual -Wcast-align -Wwrite-strings -Wconversion -Wsizeof-pointer-memaccess -Waggregate-return -Wstrict-prototypes -Woverlength-strings -Wredundant-decls -Wnested-externs -Wc++-compat -Wno-error=c++-compat -Wmissing-prototypes -Wno-error=missing-prototypes -Wdisabled-optimization -Wno-error=disabled-optimization 
 DFLAGS=-UNDEBUG -ggdb -O0
 
 ifeq ($(CC),gcc)
-	CFLAGS+=-Wdouble-promotion -Wunsafe-loop-optimizations -Wc90-c99-compat -Wjump-misses-init -Wlogical-op -Wnormalized=nfc -Wunsuffixed-float-constants -Wno-error=clobbered
+	CFLAGS+=-Wdouble-promotion -Wunsafe-loop-optimizations -Wc90-c99-compat -Wjump-misses-init -Wlogical-op -Wnormalized=nfc -Wunsuffixed-float-constants 
 else
 	ifeq ($(CC),clang)
 		CFLAGS+=-Weverything -Wno-padded


### PR DESCRIPTION
This suppresses a GCC warning documented here: #67. 

Resolve #76