### PR TITLE
Make fqinit() null check the dispatch table before use

### DIFF
--- a/function_queue.c
+++ b/function_queue.c
@@ -68,6 +68,7 @@ fqinit(struct function_queue* q, enum fqtype type, unsigned max_elements)
 		return QTEPTCINIT;
 	}
 
+	assert(q->dispatchtable != NULL);
 	assert(q->dispatchtable->init != NULL);
 	ret = q->dispatchtable->init(q, max_elements);
 


### PR DESCRIPTION
This should prevent accidental uses of NULL pointers; although , it should not be possible for the dispatch table pointer to be NULL.

Additionally, the rest of the function queue procedures should probably be checked for this.

Fix #74 