### PR TITLE
Create helper procedures for fqisfull() and fqisempty()

### DIFF
--- a/fq/indexed_array_queue.c
+++ b/fq/indexed_array_queue.c
@@ -220,10 +220,14 @@ fqresizeia(struct function_queue* q, unsigned int len, int block)
 				num_elements_to_copy2 * sizeof(*new_array));
 	}
 
+	if(q->queue.ia.size > len)
+		q->queue.ia.size = len;
+
 	q->queue.ia.front = len > 0 ? len - 1 : 0;
 	q->queue.ia.back = len > 0 ? len - 1 : 0;
 	old_array = q->queue.ia.elements;
 	q->queue.ia.elements = new_array;
+	q->queue.ia.max_size = len;
 	free(old_array);
 	return QTSUCCESS;
 }

--- a/fq/indexed_array_queue.c
+++ b/fq/indexed_array_queue.c
@@ -35,6 +35,8 @@ static enum qterror fqpopia(struct function_queue*,
 static enum qterror fqpeekia(struct function_queue*,
 		struct function_queue_element*, int);
 static enum qterror fqresizeia(struct function_queue*, unsigned int, int);
+static enum qterror fqisemptyia(struct function_queue*, int*, int);
+static enum qterror fqisfullia(struct function_queue*, int*, int);
 static unsigned int inc_and_wrap_index(unsigned int, unsigned int);
 
 /*
@@ -48,6 +50,8 @@ const struct fqdispatchtable fqdispatchtableia = {
 	fqpopia,
 	fqpeekia,
 	fqresizeia,
+	fqisemptyia,
+	fqisfullia,
 };
 
 /*
@@ -221,6 +225,41 @@ fqresizeia(struct function_queue* q, unsigned int len, int block)
 	old_array = q->queue.ia.elements;
 	q->queue.ia.elements = new_array;
 	free(old_array);
+	return QTSUCCESS;
+}
+
+/*
+ * This procedure checks if the given queue is empty. It sets the value
+ * at the address pointed to by isempty to 0 if the queue is empty.
+ * Otherwise, it sets the value pointed to by isempty to non-zero. This
+ * procedure returns an error code indicating its status. The value of q
+ * must not be NULL. The value of isempty must not be NULL.
+ */
+static enum qterror fqisemptyia(struct function_queue* q, int* isempty,
+		int block)
+{
+	(void) block;
+
+	assert(q != NULL);
+	assert(isempty != NULL);
+	*isempty = q->queue.ia.size == 0;
+	return QTSUCCESS;
+}
+
+/*
+ * This procedure checks if the given queue is full. It sets the value
+ * at the address pointed to by isfull to 0 if the queue is full.
+ * Otherwise, it sets the value pointed to by isfull to non-zero. This
+ * procedure returns an error code indicating its status. The value of q
+ * must not be NULL. The value of isfull must not be NULL.
+ */
+static enum qterror fqisfullia(struct function_queue* q, int* isfull, int block)
+{
+	(void) block;
+
+	assert(q != NULL);
+	assert(isfull != NULL);
+	*isfull = q->queue.ia.size >= q->queue.ia.max_size;
 	return QTSUCCESS;
 }
 

--- a/fq/linked_list_queue.c
+++ b/fq/linked_list_queue.c
@@ -34,6 +34,8 @@ static enum qterror fqpopll(struct function_queue*,
 static enum qterror fqpeekll(struct function_queue*,
 		struct function_queue_element*, int);
 static enum qterror fqresizell(struct function_queue*, unsigned, int);
+static enum qterror fqisemptyll(struct function_queue*, int*, int);
+static enum qterror fqisfullll(struct function_queue*, int*, int);
 
 static void fqellnode_trunc(struct fqellnode*);
 /*
@@ -47,6 +49,8 @@ const struct fqdispatchtable fqdispatchtablell = {
 	fqpopll,
 	fqpeekll,
 	fqresizell,
+	fqisemptyll,
+	fqisfullll,
 };
 
 /*
@@ -229,6 +233,42 @@ fqresizell(struct function_queue* q, unsigned int len, int block)
 		q->queue.ll.tail = NULL;
 	}
 
+	return QTSUCCESS;
+}
+
+/*
+ * This procedure checks if the given queue is empty. It sets the value
+ * at the address pointed to by isempty to 0 if the queue is empty.
+ * Otherwise, it sets the value pointed to by isempty to non-zero. This
+ * procedure returns an error code indicating its status. The value of q
+ * must not be NULL. The value of isempty must not be NULL.
+ */
+static enum qterror
+fqisemptyll(struct function_queue* q, int* isempty, int block)
+{
+	(void) block;
+
+	assert(q != NULL);
+	assert(isempty != NULL);
+	*isempty = q->queue.ll.size == 0;
+	return QTSUCCESS;
+}
+
+/*
+ * This procedure checks if the given queue is full. It sets the value
+ * at the address pointed to by isfull to 0 if the queue is full.
+ * Otherwise, it sets the value pointed to by isfull to non-zero. This
+ * procedure returns an error code indicating its status. The value of q
+ * must not be NULL. The value of isfull must not be NULL.
+ */
+static enum qterror
+fqisfullll(struct function_queue* q, int* isfull, int block)
+{
+	(void) block;
+
+	assert(q != NULL);
+	assert(isfull != NULL);
+	*isfull = q->queue.ll.size >= q->queue.ll.max_size;
 	return QTSUCCESS;
 }
 

--- a/fq/linked_list_queue.c
+++ b/fq/linked_list_queue.c
@@ -106,7 +106,7 @@ fqpushll(struct function_queue* q, void (*func)(void*), void* arg, int block)
 
 	assert(q != NULL);
 
-	if(q->queue.ia.size >= q->queue.ia.max_size)
+	if(q->queue.ll.size >= q->queue.ll.max_size)
 		return QTEFQFULL;
 
 	e.func = func;
@@ -118,7 +118,7 @@ fqpushll(struct function_queue* q, void (*func)(void*), void* arg, int block)
 
 	new_node->element = e;
 	new_node->next = NULL;
-	++q->queue.ia.size;
+	++q->queue.ll.size;
 
 	if(q->queue.ll.tail == NULL) {
 		q->queue.ll.tail = new_node;

--- a/function_queue.h
+++ b/function_queue.h
@@ -58,6 +58,8 @@ struct fqdispatchtable {
 	enum qterror (* peek)(struct function_queue*,
 			struct function_queue_element*, int);
 	enum qterror (* resize)(struct function_queue*, unsigned int, int);
+	enum qterror (* isempty)(struct function_queue*, int*, int);
+	enum qterror (* isfull)(struct function_queue*, int*, int);
 };
 
 struct function_queue {
@@ -87,8 +89,8 @@ enum qterror fqpop(struct function_queue*, struct function_queue_element*,
 		int);
 enum qterror fqpeek(struct function_queue*, struct function_queue_element*,
 		int);
-enum qterror fqisempty(struct function_queue*, int*);
-enum qterror fqisfull(struct function_queue*, int*);
+enum qterror fqisempty(struct function_queue*, int*, int);
+enum qterror fqisfull(struct function_queue*, int*, int);
 enum qterror fqresize(struct function_queue*, unsigned int, int);
 
 #ifdef __cplusplus


### PR DESCRIPTION
Additionally, fix some function queue size-related bugs
 - Indexed array queue resize procedure now properly modifies the size
   of the queue (internally) when it exceeds the new maximum size.
 - Indexed array queue resize procedure now properly modifies the
   maximum size of the queue (internally).
 - The linked list queue push procedure no longer references members of
   the indexed array queue structure.

Resolve #91 